### PR TITLE
feat: allow PascalCase string schemas TypeScript does too

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,106 +1,118 @@
 import { z } from "zod";
 
 /** @deprecated */
-export const ImportsNotUsedAsValuesSchema = z.nativeEnum({
-	Error: 2,
-	Preserve: 1,
-	Remove: 0,
-} as const);
+export const ImportsNotUsedAsValuesSchema = z.enum([
+	"error",
+	"preserve",
+	"remove",
+]);
 
 export type ImportsNotUsedAsValues = z.infer<
 	typeof ImportsNotUsedAsValuesSchema
 >;
 
-export const JsxEmitSchema = z.nativeEnum({
-	None: "none",
-	Preserve: "preserve",
-	React: "react",
-	ReactJSX: "react-jsx",
-	ReactJSXDev: "react-jsxdev",
-	ReactNative: "react-native",
-} as const);
+export const JsxEmitSchema = z.enum([
+	"none",
+	"preserve",
+	"react",
+	"react-jsx",
+	"react-jsxdev",
+	"react-native",
+]);
 
 export type JsxEmit = z.infer<typeof JsxEmitSchema>;
 
-export const ModuleKindSchema = z.nativeEnum({
-	AMD: "amd",
-	CommonJS: "commonjs",
-	ES6: "es6",
-	ES2015: "es2015",
-	ES2020: "es2020",
-	ES2022: "es2022",
-	ESNext: "esnext",
-	Node16: "node16",
-	Node18: "node18",
-	NodeNext: "nodenext",
-	None: "none",
-	Preserve: "preserve",
-	System: "system",
-	UMD: "umd",
-} as const);
+export const ModuleKindSchema = z.enum([
+	"amd",
+	"AMD",
+	"commonjs",
+	"CommonJS",
+	"es2015",
+	"ES2015",
+	"es2020",
+	"ES2020",
+	"es2022",
+	"ES2022",
+	"es6",
+	"ES6",
+	"esnext",
+	"ESNext",
+	"node16",
+	"Node16",
+	"node18",
+	"Node18",
+	"nodenext",
+	"NodeNext",
+	"none",
+	"None",
+	"preserve",
+	"Preserve",
+	"system",
+	"System",
+	"umd",
+	"UMD",
+]);
 
 export type ModuleKind = z.infer<typeof ModuleKindSchema>;
 
-export const ModuleResolutionKindSchema = z.nativeEnum({
-	Classic: "classic",
-
-	/** @deprecated Renamed to `Node10` */
-	Node: "node",
-
-	/** @deprecated Renamed to `Node10` */
-	Bundler: "bundler",
-
-	Node10: "node10",
-	Node16: "node16",
-	NodeJs: "node",
-	NodeNext: "nodenext",
-} as const);
+export const ModuleResolutionKindSchema = z.enum([
+	"bundler",
+	"Bundler",
+	"classic",
+	"Classic",
+	"node",
+	"node",
+	"Node",
+	"node10",
+	"Node10",
+	"node16",
+	"Node16",
+	"NodeJs",
+	"nodenext",
+	"NodeNext",
+]);
 
 export type ModuleResolutionKind = z.infer<typeof ModuleResolutionKindSchema>;
 
-export const ModuleDetectionKindSchema = z.nativeEnum({
-	/**
-	 * Files with imports, exports and/or import.meta are considered modules
-	 */
-	Legacy: 1,
-
-	/**
-	 * Legacy, but also files with jsx under react-jsx or react-jsxdev and esm mode files under moduleResolution: node16+
-	 */
-	Auto: 2,
-
-	/**
-	 * Consider all non-declaration files modules, regardless of present syntax
-	 */
-	Force: 3,
-} as const);
+export const ModuleDetectionKindSchema = z.enum(["auto", "force", "legacy"]);
 
 export type ModuleDetectionKind = z.infer<typeof ModuleDetectionKindSchema>;
 
-export const NewLineKindSchema = z.nativeEnum({
-	CarriageReturnLineFeed: 0,
-	LineFeed: 1,
-} as const);
+export const NewLineKindSchema = z.enum(["crlf", "lf"]);
 
 export type NewLineKind = z.infer<typeof NewLineKindSchema>;
 
-export const ScriptTargetSchema = z.nativeEnum({
-	/** @deprecated */
-	ES3: 0,
-	ES5: 1,
-	ES2015: 2,
-	ES2016: 3,
-	ES2017: 4,
-	ES2018: 5,
-	ES2019: 6,
-	ES2020: 7,
-	ES2021: 8,
-	ES2022: 9,
-	ES2023: 10,
-	ES2024: 11,
-	ESNext: 99,
-	JSON: 100,
-	Latest: 99,
-} as const);
+export const ScriptTargetSchema = z.enum([
+	"es2015",
+	"ES2015",
+	"es2016",
+	"ES2016",
+	"es2017",
+	"ES2017",
+	"es2018",
+	"ES2018",
+	"es2019",
+	"ES2019",
+	"es2020",
+	"ES2020",
+	"es2021",
+	"ES2021",
+	"es2022",
+	"ES2022",
+	"es2023",
+	"ES2023",
+	"es2024",
+	"ES2024",
+	"es3",
+	"ES3",
+	"es5",
+	"ES5",
+	"esnext",
+	"ESNext",
+	"json",
+	"JSON",
+	"latest",
+	"Latest",
+]);
 
 export type ScriptTarget = z.infer<typeof ScriptTargetSchema>;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #18
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/zod-tsconfig/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/zod-tsconfig/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Also switches from `z.nativeEnum` to just normal `z.enum` for all values. The numeric ones were incorrectly the literals before.

⚙️ 