### PR TITLE
fix: accept references arrays

### DIFF
--- a/src/tsconfig.ts
+++ b/src/tsconfig.ts
@@ -10,7 +10,7 @@ export const TSConfigSchema = z
 		extends: z.union([z.string(), z.array(z.string())]),
 		files: z.array(z.string()),
 		include: z.array(z.string()),
-		references: ReferencesSchema,
+		references: z.array(ReferencesSchema),
 	})
 	.optional();
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #59
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/zod-tsconfig/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/zod-tsconfig/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updates `TSConfigSchema` to validate `references` as an array of project references, matching the TSConfig shape described in #59.

Fixes #59.

⚙
